### PR TITLE
ACNA-337 - clear .env vars during reload

### DIFF
--- a/src/Config.js
+++ b/src/Config.js
@@ -36,7 +36,7 @@ const readFile = (file) => {
 
 class Config {
   reload() {
-    dotenv()
+    dotenv(true)
 
     const configBasePath = process.env['XDG_CONFIG_HOME'] || path.join(os.homedir(), '.config')
     this.global = { file: process.env['AIO_CONFIG_FILE'] || path.join(configBasePath, 'aio') }

--- a/test/dotenv.js
+++ b/test/dotenv.js
@@ -55,14 +55,14 @@ test('should set global symbol', () => {
 })
 
 test('shouldnt do anything if global symbol is present', () => {
-  global[envFile] = '/project/.env'
+  global[envFile] = path.resolve('/project/.env')
   dotenv()
   expect(process.env).toEqual(processenv)
   expect(fs.readFileSync).not.toHaveBeenCalled()
 })
 
 test('shouldnt do anything if global symbol is present (unless forced)', () => {
-  global[envFile] = '/project/.env'
+  global[envFile] = path.resolve('/project/.env')
   dotenv(true)
   expect(process.env).toEqual(processenv)
   expect(fs.readFileSync).toHaveBeenCalled()

--- a/test/dotenv.js
+++ b/test/dotenv.js
@@ -15,8 +15,10 @@ const fs = require('fs')
 const path = require('path')
 const os = require('os')
 const debug = require('debug').mock
-const status = Symbol.for('aio-cli-config.dotenv')
+const envFile = Symbol.for('aio-cli-config.envfile')
+const envVars = Symbol.for(`aio-cli-config.envVars`)
 let processenv, processcwd
+jest.spyOn(fs, 'readFileSync')
 
 beforeAll(() => {
   fs.mkdirSync('/project/')
@@ -32,7 +34,8 @@ afterEach(() => {
   jest.clearAllMocks()
   process.env = processenv
   process.cwd = processcwd
-  global[status] = undefined
+  delete global[envFile]
+  delete global[envVars]
 })
 
 test('is a function', () => expect(dotenv).toBeInstanceOf(Function))
@@ -40,20 +43,29 @@ test('is a function', () => expect(dotenv).toBeInstanceOf(Function))
 test('if file doesnt exist no change to process.env', () => {
   dotenv()
   expect(process.env).toEqual(processenv)
-  expect(global[status]).toEqual(path.resolve('/project/.env'))
+  expect(global[envFile]).toEqual(path.resolve('/project/.env'))
+  expect(fs.readFileSync).toHaveBeenCalled()
 })
 
 test('should set global symbol', () => {
-  global[status] = true
-  dotenv(debug)
-  expect(global[status]).toEqual(path.resolve('/project/.env'))
+  global[envFile] = undefined
+  dotenv()
+  expect(global[envFile]).toEqual(path.resolve('/project/.env'))
+  expect(fs.readFileSync).toHaveBeenCalled()
 })
 
 test('shouldnt do anything if global symbol is present', () => {
-  global[status] = true
+  global[envFile] = '/project/.env'
   dotenv()
   expect(process.env).toEqual(processenv)
-  expect(debug).not.toHaveBeenCalled()
+  expect(fs.readFileSync).not.toHaveBeenCalled()
+})
+
+test('shouldnt do anything if global symbol is present (unless forced)', () => {
+  global[envFile] = '/project/.env'
+  dotenv(true)
+  expect(process.env).toEqual(processenv)
+  expect(fs.readFileSync).toHaveBeenCalled()
 })
 
 describe(('error handling'), () => {
@@ -74,6 +86,21 @@ describe(('error handling'), () => {
   })
 })
 
+describe('clear', () => {
+  afterEach(() => {
+    fs.unlinkSync('/project/.env')
+  })
+
+  test('should clear existing envVars', () => {
+    fs.writeFileSync('/project/.env', fixtureFile('single'))
+    dotenv()
+    expect(process.env).toEqual({ ...{ A: '12', B: '12', C: '12' }, ...processenv })
+    fs.writeFileSync('/project/.env', fixtureFile('empty'))
+    dotenv(true)
+    expect(process.env).toEqual(processenv)
+  })
+})
+
 describe('parse', () => {
   afterEach(() => {
     fs.unlinkSync('/project/.env')
@@ -89,34 +116,39 @@ describe('parse', () => {
     fs.writeFileSync('/project/.env', fixtureFile('comment'))
     dotenv()
     expect(process.env).toEqual({ ...{ A: '#comment', B: '1', C: `12${os.EOL}` }, ...processenv })
-    expect(debug).toHaveBeenLastCalledWith('added environment variables: A, B, C')
+    expect(debug).toHaveBeenLastCalledWith('added environment variable(s): A, B, C')
+    expect(global[envVars]).toEqual(['A', 'B', 'C'])
   })
 
   test('multiline', () => {
     fs.writeFileSync('/project/.env', fixtureFile('multiline'))
     dotenv()
     expect(process.env).toEqual({ ...{ A: `${os.EOL}12`, B: `${os.EOL}12`, C: '1' }, ...processenv })
-    expect(debug).toHaveBeenLastCalledWith('added environment variables: A, B, C')
+    expect(debug).toHaveBeenLastCalledWith('added environment variable(s): A, B, C')
+    expect(global[envVars]).toEqual(['A', 'B', 'C'])
   })
 
   test('quotes', () => {
     fs.writeFileSync('/project/.env', fixtureFile('quotes'))
     dotenv()
     expect(process.env).toEqual({ ...{ A: `   12'  ${os.EOL}`, B: `   12" ${os.EOL}`, C: '  12  ' }, ...processenv })
-    expect(debug).toHaveBeenLastCalledWith('added environment variables: A, B, C')
+    expect(debug).toHaveBeenLastCalledWith('added environment variable(s): A, B, C')
+    expect(global[envVars]).toEqual(['A', 'B', 'C'])
   })
 
   test('single', () => {
     fs.writeFileSync('/project/.env', fixtureFile('single'))
     dotenv()
     expect(process.env).toEqual({ ...{ A: '12', B: '12', C: '12' }, ...processenv })
-    expect(debug).toHaveBeenLastCalledWith('added environment variables: A, B, C')
+    expect(debug).toHaveBeenLastCalledWith('added environment variable(s): A, B, C')
+    expect(global[envVars]).toEqual(['A', 'B', 'C'])
   })
 })
 
 test('should not overwrite process.env values', () => {
   process.env['A'] = 12
-  fs.writeFileSync('/project/.env', 'A=1')
+  fs.writeFileSync('/project/.env', 'A=1\nB=12')
   dotenv()
+  expect(process.env['B']).toEqual('12')
   expect(process.env['A']).toEqual('12')
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

fix for #2 

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
env vars were never overridden if they exist. now hoisted variables are stored and removed before a reload
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
added coverage

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
