### PR TITLE
[WIP] ACNA-344 - Migrate aio-cli-config to aio-cna-core-config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "@adobe/aio-cli-config",
+  "name": "@adobe/aio-cna-core-config",
   "version": "1.0.12",
-  "description": "Adobe I/O configuration module for the AIO CLI",
+  "description": "Adobe I/O Configuration Module",
   "main": "./src",
-  "repository": "https://github.com/adobe/aio-cli-config",
-  "author": "rudd@adobe.com",
+  "repository": "https://github.com/adobe/aio-cna-core-config",
+  "author": "Adobe Inc.",
   "license": "Apache-2.0",
   "engines": {
     "node": ">=8.10.0"


### PR DESCRIPTION
The aio-cli-config module started as part of the AIO CLI project with no dependencies on OClif or the AIO CLI any more. As such it becomes generally usable and we should probably move that to a more SDK-level module adobeio-cna-core-config.

**UPDATE:** see new procedure below

Tasks to consider:
- [x] Rename the module in package.json
- [ ] Rename the module repository
    - [ ] Make sure Travis CI still works with the new repo
    - [ ] Make sure Codecov still works with the new repo
- [ ] npm deprecate the old aio-cli-config module
- [ ] Update dependencies (tracked by separate issues)
     - [ ] aio-cli-plugin-jwt-auth
     - [ ] aio-cli-plugin-console
     - [ ] aio-cli-plugin-runtime
     - [ ] ???
